### PR TITLE
Fixed SelectSingleVC Loading Users with nil names

### DIFF
--- a/SwiftParseChat/SearchViewController.swift
+++ b/SwiftParseChat/SearchViewController.swift
@@ -33,22 +33,15 @@ class SearchViewController: UITableViewController, UITableViewDelegate, UITableV
         let user = PFUser.currentUser()
         var query = PFQuery(className: PF_USER_CLASS_NAME)
         query.whereKey(PF_USER_OBJECTID, notEqualTo: user.objectId)
-        
-        
-        
+
         query.orderByAscending(PF_USER_FULLNAME)
         query.limit = 1000
         query.findObjectsInBackgroundWithBlock { (objects: [AnyObject]!, error: NSError!) -> Void in
             if error == nil{
                 self.users.removeAll(keepCapacity: false)
-                for obj in objects {
-                    if let username = (obj as! PFUser)[PF_USER_FULLNAME] as? String {
-                        self.users.append(obj as! PFUser)
-                    }
-                }
-                
-                //self.users += objects as! [PFUser]!
+                self.users += objects as! [PFUser]!
                 self.tableView.reloadData()
+                
             } else {
                 ProgressHUD.showError("Network error")
             }

--- a/SwiftParseChat/SearchViewController.swift
+++ b/SwiftParseChat/SearchViewController.swift
@@ -30,20 +30,29 @@ class SearchViewController: UITableViewController, UITableViewDelegate, UITableV
     }
     
     func loadUsers() {
-        var user = PFUser.currentUser()
-        
+        let user = PFUser.currentUser()
         var query = PFQuery(className: PF_USER_CLASS_NAME)
         query.whereKey(PF_USER_OBJECTID, notEqualTo: user.objectId)
+        
+        
+        
         query.orderByAscending(PF_USER_FULLNAME)
         query.limit = 1000
         query.findObjectsInBackgroundWithBlock { (objects: [AnyObject]!, error: NSError!) -> Void in
-            if error == nil {
+            if error == nil{
                 self.users.removeAll(keepCapacity: false)
-                self.users += objects as! [PFUser]!
+                for obj in objects {
+                    if let username = (obj as! PFUser)[PF_USER_FULLNAME] as? String {
+                        self.users.append(obj as! PFUser)
+                    }
+                }
+                
+                //self.users += objects as! [PFUser]!
                 self.tableView.reloadData()
             } else {
                 ProgressHUD.showError("Network error")
             }
+            
         }
     }
     

--- a/SwiftParseChat/SelectSingleViewController.swift
+++ b/SwiftParseChat/SelectSingleViewController.swift
@@ -44,16 +44,24 @@ class SelectSingleViewController: UITableViewController, UISearchBarDelegate {
         let user = PFUser.currentUser()
         var query = PFQuery(className: PF_USER_CLASS_NAME)
         query.whereKey(PF_USER_OBJECTID, notEqualTo: user.objectId)
+
         query.orderByAscending(PF_USER_FULLNAME)
         query.limit = 1000
         query.findObjectsInBackgroundWithBlock { (objects: [AnyObject]!, error: NSError!) -> Void in
-            if error == nil {
+            if error == nil{
                 self.users.removeAll(keepCapacity: false)
-                self.users += objects as! [PFUser]!
+                for obj in objects {
+                    if let username = (obj as! PFUser)[PF_USER_FULLNAME] as? String {
+                        self.users.append(obj as! PFUser)
+                    }
+                }
+                
+                //self.users += objects as! [PFUser]!
                 self.tableView.reloadData()
             } else {
                 ProgressHUD.showError("Network error")
             }
+            
         }
     }
     
@@ -147,5 +155,6 @@ class SelectSingleViewController: UITableViewController, UISearchBarDelegate {
         
         self.loadUsers()
     }
-
 }
+
+


### PR DESCRIPTION
SelectSingleVC load users with nil names. Modified loadUsers() to prevent loading users with nil names. 
<img width="397" alt="screen shot 2015-07-14 at 12 22 40 am" src="https://cloud.githubusercontent.com/assets/9794205/8657968/8489ea74-29be-11e5-9453-8e5039a67ddd.png">

This problem also occurs when user selects "Multiple Recipients". Could you double check the Parse database?
